### PR TITLE
Update DataClasses.kt

### DIFF
--- a/src/i_introduction/_6_Data_Classes/DataClasses.kt
+++ b/src/i_introduction/_6_Data_Classes/DataClasses.kt
@@ -6,8 +6,8 @@ import util.doc6
 fun todoTask6(): Nothing = TODO(
     """
         Convert 'JavaCode6.Person' class to Kotlin.
-        Then add an annotation `data` to the resulting class.
-        This annotation means the compiler will generate a bunch of useful methods in this class: `equals`/`hashCode`, `toString` and some others.
+        Then add a modifier `data` to the resulting class (this should look like this: "data class Person").
+        This modifier means the compiler will generate a bunch of useful methods in this class: `equals`/`hashCode`, `toString` and some others.
         The `task6` function should return a list of persons.
     """,
     documentation = doc6(),


### PR DESCRIPTION
Dmitry Jemerov clarified that a data modifier should be used here (instead of an annotation): "The correct fix is to change "annotation" to "modifier" in the text. "data" used to be an annotation in pre-release versions of Kotlin, but now it's a modifier."
